### PR TITLE
Full test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+coverage
 dist
 dist-ssr
 *.tgz

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.10.5",
     "@vitejs/plugin-vue": "^4.5.2",
+    "@vitest/coverage-v8": "^1.1.0",
     "@vitest/ui": "^1.0.4",
     "@vue/eslint-config-prettier": "^8.0.0",
     "@vue/eslint-config-typescript": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ devDependencies:
   '@vitejs/plugin-vue':
     specifier: ^4.5.2
     version: 4.5.2(vite@5.0.10)(vue@3.3.12)
+  '@vitest/coverage-v8':
+    specifier: ^1.1.0
+    version: 1.1.0(vitest@1.0.4)
   '@vitest/ui':
     specifier: ^1.0.4
     version: 1.0.4(vitest@1.0.4)
@@ -84,6 +87,14 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.20
+    dev: true
+
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
@@ -126,6 +137,10 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+    dev: true
+
+  /@bcoe/v8-coverage@0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -400,6 +415,11 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: true
+
+  /@istanbuljs/schema@0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
     dev: true
 
   /@jest/expect-utils@29.7.0:
@@ -935,6 +955,29 @@ packages:
     dependencies:
       vite: 5.0.10(@types/node@20.10.5)
       vue: 3.3.12(typescript@5.3.3)
+    dev: true
+
+  /@vitest/coverage-v8@1.1.0(vitest@1.0.4):
+    resolution: {integrity: sha512-kHQRk70vTdXAyQY2C0vKOHPyQD/R6IUzcGdO4vCuyr4alE5Yg1+Sk2jSdjlIrTTXdcNEs+ReWVM09mmSFJpzyQ==}
+    peerDependencies:
+      vitest: ^1.0.0
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      magic-string: 0.30.5
+      magicast: 0.3.2
+      picocolors: 1.0.0
+      std-env: 3.6.0
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.2.0
+      vitest: 1.0.4(@types/node@20.10.5)(@vitest/ui@1.0.4)(happy-dom@12.10.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@vitest/expect@1.0.4:
@@ -1481,6 +1524,10 @@ packages:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
+    dev: true
+
+  /convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
 
   /create-require@1.1.1:
@@ -2095,6 +2142,10 @@ packages:
     hasBin: true
     dev: true
 
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -2234,6 +2285,39 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports@3.1.6:
+    resolution: {integrity: sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
     dev: true
 
   /jackspeak@2.3.6:
@@ -2436,6 +2520,21 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magicast@0.3.2:
+    resolution: {integrity: sha512-Fjwkl6a0syt9TFN0JSYpOybxiMCkYNEeOTnOTNRbjphirLakznZXAqrXgj/7GG3D1dvETONNwrBfinvAbpunDg==}
+    dependencies:
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
+      source-map-js: 1.0.2
+    dev: true
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.5.4
     dev: true
 
   /make-error@1.3.6:
@@ -3137,6 +3236,15 @@ packages:
       - ts-node
     dev: true
 
+  /test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.1.6
+      minimatch: 3.1.2
+    dev: true
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -3308,6 +3416,15 @@ packages:
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /v8-to-istanbul@9.2.0:
+    resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.20
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
     dev: true
 
   /validator@13.11.0:

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { ImageSizeRange } from './types/util'
 import Gravatar from './components/Gravatar.vue'
-import { type Gravatar as GravatarType, GravatarPlaceholderOption, GravatarRatingOption } from './types/gravatar'
+import { type GravatarType, GravatarPlaceholderOption, GravatarRatingOption } from './types/gravatar'
 
 const config = ref<GravatarType>({
   email: 'test@example.org',

--- a/src/components/Gravatar.vue
+++ b/src/components/Gravatar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useGravatar } from '../composables/useGravatar'
-import { type Gravatar as GravatarType } from '../types/gravatar'
+import { type GravatarType } from '../types/gravatar'
 
 const props = defineProps<GravatarType & { alt?: string }>()
 

--- a/src/composables/useGravatar.ts
+++ b/src/composables/useGravatar.ts
@@ -17,7 +17,7 @@ export const useGravatar = (image: GravatarType): GravatarComposableReturn => {
       default: image.default,
       rating: image.rating,
       forceDefault: image.forceDefault,
-      extenstion: image.extenstion
+      extension: image.extension
     }
   })
   const emptyParams = computed<boolean>(() => Object.values(imageParams.value).every((item) => item === undefined))
@@ -28,7 +28,8 @@ export const useGravatar = (image: GravatarType): GravatarComposableReturn => {
   async function buildGravatarUrl(): Promise<void> {
     const gravatarBaseUrl: string = 'https://gravatar.com/avatar'
     const gravatarEmailHash: string = await sha256(email.value)
-    const gravatarSource = new URL(`${gravatarBaseUrl}/${gravatarEmailHash}`)
+    const pathname = imageParams.value.extension ? gravatarEmailHash + imageParams.value.extension : gravatarEmailHash
+    const gravatarSource = new URL(`${gravatarBaseUrl}/${pathname}`)
 
     if (emptyParams.value) {
       source.value = gravatarSource
@@ -36,8 +37,8 @@ export const useGravatar = (image: GravatarType): GravatarComposableReturn => {
     }
 
     for (const [key, value] of Object.entries(imageParams.value)) {
-      if (!value) continue
-      gravatarSource.searchParams.append(key, value.toString())
+      if (!value || key === 'extension') continue
+      gravatarSource.searchParams.append(key.toLowerCase(), value.toString())
     }
 
     source.value = gravatarSource

--- a/src/composables/useGravatar.ts
+++ b/src/composables/useGravatar.ts
@@ -1,11 +1,11 @@
 import { ref, computed, watch } from 'vue'
-import type { Gravatar, GravatarComposableReturn, ImageParams } from '../types/gravatar'
+import type { GravatarType, GravatarComposableReturn, ImageParams } from '../types/gravatar'
 import type { Email, ImageSize } from '../types/util'
 import { sha256 } from '../utils/sha256'
 import { createEmail } from '../utils/email'
 import { imageSize } from '../utils/size'
 
-export const useGravatar = (image: Gravatar): GravatarComposableReturn => {
+export const useGravatar = (image: GravatarType): GravatarComposableReturn => {
   const source = ref<URL | null>(null)
 
   const gravatar = computed<string>(() => source.value?.toString() ?? '')

--- a/src/types/gravatar.ts
+++ b/src/types/gravatar.ts
@@ -31,7 +31,7 @@ export type ImageParams = {
   extenstion?: '.jpg'
 }
 
-export type Gravatar = { email: Email } & ImageParams
+export type GravatarType = { email: Email } & ImageParams
 
 export type GravatarComposableReturn = {
   source: Ref<URL | null>

--- a/src/types/gravatar.ts
+++ b/src/types/gravatar.ts
@@ -28,7 +28,7 @@ export type ImageParams = {
   default?: GravatarPlaceholder
   rating?: GravatarRating
   forceDefault?: 'y'
-  extenstion?: '.jpg'
+  extension?: '.jpg'
 }
 
 export type GravatarType = { email: Email } & ImageParams

--- a/tests/components/Gravatar.test.ts
+++ b/tests/components/Gravatar.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import Gravatar from '../../src/components/Gravatar.vue'
+import { GravatarPlaceholderOption, GravatarRatingOption } from '../../src/types/gravatar'
 
 describe('gravatar component', () => {
   let gravatar: VueWrapper<InstanceType<typeof Gravatar>>
@@ -40,5 +41,27 @@ describe('gravatar component', () => {
 
     expect(gravatar.vm.alt).toEqual(testAlt)
     expect(gravatar.find('img').attributes().alt).toEqual(testAlt)
+  })
+
+  describe('gravatar placeholders', () => {
+    test('placeholders match gravatar docs', () => {
+      const fixedValues: string[] = ['404', 'mp', 'identicon', 'monsterid', 'mavatar', 'retro', 'robohash', 'blank']
+      const enumValues: string[] = Object.values(GravatarPlaceholderOption)
+
+      for (const placeholder of enumValues) {
+        expect(fixedValues).toContainEqual(placeholder)
+      }
+    })
+  })
+
+  describe('gravatar rating', () => {
+    test('rating options match gravatar docs', () => {
+      const fixedValues: string[] = ['g', 'pg', 'r', 'x']
+      const enumValues: string[] = Object.values(GravatarRatingOption)
+
+      for (const ratingOption of enumValues) {
+        expect(fixedValues).toContainEqual(ratingOption)
+      }
+    })
   })
 })

--- a/tests/composables/useGravatar.test.ts
+++ b/tests/composables/useGravatar.test.ts
@@ -1,0 +1,105 @@
+import { expectTypeOf } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { reactive } from 'vue'
+import type { GravatarComposableReturn, GravatarType } from '../../src/types/gravatar'
+import { useGravatar } from '../../src/composables/useGravatar'
+import { exampleHash } from '../helpers/exampleHash'
+import { ImageSize, type Email } from '../../src/types/util'
+
+describe('useGravatar', () => {
+  it('returns correct type', () => {
+    expectTypeOf(useGravatar({ email: 'test@example.org' })).toMatchTypeOf<GravatarComposableReturn>()
+  })
+
+  it('can be used without image params', async () => {
+    const correctUrl: URL = new URL(`https://gravatar.com/avatar/${exampleHash}`)
+    const { source, gravatar, email, emptyParams, buildGravatarUrl } = useGravatar({ email: 'test@example.org' })
+
+    await buildGravatarUrl()
+
+    expect(source.value).toEqual(correctUrl)
+    expect(gravatar.value).toEqual(correctUrl.toString())
+    expect(email.value).toEqual('test@example.org')
+    expectTypeOf(email.value).toMatchTypeOf<Email>()
+    expect(emptyParams.value).toBe(true)
+  })
+
+  it('can be used with image params', async () => {
+    const image: GravatarType = {
+      email: 'test@example.org',
+      size: 80,
+      default: 'mp',
+      rating: 'g',
+      forceDefault: 'y',
+      extension: '.jpg'
+    }
+    const { email, ...imageParams } = image
+    const expectedUrl: URL = new URL(
+      `https://gravatar.com/avatar/${exampleHash}.jpg?size=80&default=mp&rating=g&forcedefault=y`
+    )
+
+    const composable = useGravatar(image)
+    await composable.buildGravatarUrl()
+
+    expect(composable.source.value).toEqual(expectedUrl)
+    expect(composable.gravatar.value).toEqual(expectedUrl.toString())
+    expect(composable.email.value).toEqual(email)
+    expect(composable.imageParams.value).toEqual(imageParams)
+    expect(composable.emptyParams.value).toBe(false)
+
+    expectTypeOf(composable.email.value).toMatchTypeOf<Email>()
+    expectTypeOf(composable.size.value).toMatchTypeOf<ImageSize>()
+  })
+
+  it('always returns valid string as gravatar url', () => {
+    const image: GravatarType = { email: 'test@example.org' }
+    const { gravatar } = useGravatar(image)
+
+    expect(gravatar.value).toStrictEqual('')
+  })
+
+  it('watches for email value', async () => {
+    const image = reactive<GravatarType>({ email: 'test@example.org' })
+    const { email, gravatar, buildGravatarUrl } = useGravatar(image)
+
+    await buildGravatarUrl()
+    await flushPromises()
+
+    expect(email.value).toEqual('test@example.org')
+    expect(gravatar.value).toEqual(`https://gravatar.com/avatar/${exampleHash}`)
+
+    image.email = 'example@test.com'
+
+    await flushPromises()
+
+    expect(email.value).toEqual('example@test.com')
+    expect(gravatar.value).not.toEqual(`https://gravatar.com/avatar/${exampleHash}`)
+  })
+
+  it('watches for image params change', async () => {
+    const image = reactive<GravatarType>({
+      email: 'test@example.org',
+      size: 80,
+      default: 'mp',
+      rating: 'g',
+      forceDefault: 'y',
+      extension: '.jpg'
+    })
+    const { gravatar, buildGravatarUrl } = useGravatar(image)
+
+    await buildGravatarUrl()
+    await flushPromises()
+
+    delete image.forceDefault
+    delete image.extension
+    image.size = 400
+    image.default = 'retro'
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    await flushPromises()
+
+    const expectedNewUrl: string = `https://gravatar.com/avatar/${exampleHash}?size=400&default=retro&rating=g`
+
+    expect(gravatar.value).toEqual(expectedNewUrl)
+  })
+})

--- a/tests/helpers/exampleHash.ts
+++ b/tests/helpers/exampleHash.ts
@@ -1,0 +1,4 @@
+/**
+ * SHA-256 digest for `test@example.org`
+ */
+export const exampleHash = '388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69'

--- a/tests/utils/sha256.test.ts
+++ b/tests/utils/sha256.test.ts
@@ -1,4 +1,5 @@
 import { sha256 } from '../../src/utils/sha256'
+import { exampleHash } from '../helpers/exampleHash'
 
 describe('sha256 hash util', () => {
   it('produces 64 characters hex digest', async () => {
@@ -9,7 +10,7 @@ describe('sha256 hash util', () => {
   })
 
   it('produces correct hash', async () => {
-    const expected: string = '388c735eec8225c4ad7a507944dd0a975296baea383198aa87177f29af2c6f69'
+    const expected: string = exampleHash
     const hash = await sha256('test@example.org')
 
     expect(hash).toStrictEqual(expected)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,16 @@ export default defineConfig({
   plugins: [vue(), dts({ rollupTypes: true })],
   test: {
     globals: true,
-    environment: 'happy-dom'
+    environment: 'happy-dom',
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      include: ['src/components', 'src/composables', 'src/types', 'src/utils']
+    },
+    typecheck: {
+      enabled: true,
+      checker: 'vue-tsc'
+    }
   },
   build: {
     lib: {


### PR DESCRIPTION
# General description

This PR introduces full test coverage for package code. 

Playground files are currently excluded from testing since they are not a part of a library.

# Changelog

* Test suite for `useGravatar` composable
* Test suites for `GravatarPlaceholderOption` and `GravatarRatingOption` enums
* Fixed a typo in `GravatarType` property (`extension` instead of `extenstion`)
* Renamed type `Gravatar` to `GravatarType` to avoid possible conflicts with component name

# New dependencies

*  [@vitest/coverage-v8](https://www.npmjs.com/package/@vitest/coverage-v8)